### PR TITLE
Small trick to add interactive socket

### DIFF
--- a/crypto_commons/netcat/netcat_commons.py
+++ b/crypto_commons/netcat/netcat_commons.py
@@ -1,4 +1,5 @@
 import socket
+import telnetlib
 
 import re
 
@@ -44,3 +45,9 @@ def receive_until_match(s, regex, timeout=1.0, limit=-1):
 
 def send(s, payload):
     s.sendall(payload + "\n")
+
+
+def interactive(s):
+    t = new telnetlib.Telnet()
+    t.s = s
+    t.interact()


### PR DESCRIPTION
Sometimes in CTF you want to manually interact on the socket.
This PR add a simple method to make the socket interactive 
(depends on telnetlib that is bundled in python by default)